### PR TITLE
fix gulp-inline-resize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 public/*.*
 public/css
 public/js
-
+build/
 
 # Logs
 logs

--- a/app/templates/layouts/default.swig
+++ b/app/templates/layouts/default.swig
@@ -4,9 +4,9 @@
         <meta charset="utf-8">
         <title>{% block pagetitle %}{% endblock %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      
-        <link rel="stylesheet" href="/css/main.css">
-        
+
+        <link rel="stylesheet" href="/main.css">
+
         <link href='http://fonts.googleapis.com/css?family=Lato:300,400%7CRaleway:100,400,300,500,600,700%7COpen+Sans:400,500,600' rel='stylesheet' type='text/css'>
 
 

--- a/app/templates/pages/inspiration.swig
+++ b/app/templates/pages/inspiration.swig
@@ -26,7 +26,7 @@
 
 <section class="image-bg bg-dark parallax overlay pt160 pb160 pt-xs-40 pb-xs-40">
     <div class="background-image-holder">
-        <img alt="Background Image" class="background-image" src="/img/KL-Visuals-Level2/KL-INSPIRATION-02-Haarfarben.jpg;1408w" />
+        <img alt="Background Image" class="background-image" src="./img/KL-Visuals-Level2/KL-INSPIRATION-02-Haarfarben.jpg;1408w" />
     </div>
     <div class="container">
         <div class="row">
@@ -42,7 +42,7 @@
 </section>
 <section class="image-bg bg-dark parallax overlay pt160 pb160 pt-xs-40 pb-xs-40">
     <div class="background-image-holder">
-        <img alt="Background Image" class="background-image" src="/img/KL-Visuals-Level2/KL-INSPIRATION-03-Blondierungen.jpg;100w" />
+        <img alt="Background Image" class="background-image" src="./img/KL-Visuals-Level2/KL-INSPIRATION-03-Blondierungen.jpg;100w" />
     </div>
     <div class="container">
         <div class="row">

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gulp-swig": "^0.7.4",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
+    "merge-stream": "^1.0.0",
     "node-libs-browser": "^0.5.2",
     "node-sass": "^3.2.0"
   }


### PR DESCRIPTION
Important notes:
- paths to images need to be _relative_
- I created a separate `build` directory since (some) files in the `assets` folder needed to be piped through the inline-resizer as well
